### PR TITLE
Address errors in `SeriesRemoveWarningDialog` and `CrashReporter` (Fixes #170)

### DIFF
--- a/bin/dicomsort
+++ b/bin/dicomsort
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/dicomsort/gui/core.py
+++ b/dicomsort/gui/core.py
@@ -9,7 +9,7 @@ from dicomsort.dicomsorter import DicomSorter
 from dicomsort.errors import DicomFolderError
 from dicomsort.gui import errors, events, icons, preferences, widgets
 from dicomsort.gui.dialogs import (
-    AboutDlg, CrashReporter, HelpDlg, QuickRenameDlg, UpdateDlg
+    AboutDlg, CrashReporter, HelpDlg, QuickRenameDialog, UpdateDialog
 )
 from dicomsort.gui.update import UpdateChecker
 
@@ -78,7 +78,7 @@ class MainFrame(wx.Frame):
         self.SetStatusText("Ready...")
 
     def OnNewVersion(self, evnt):
-        dlg = UpdateDlg(self, evnt.version)
+        dlg = UpdateDialog(self, evnt.version)
         dlg.Show()
 
     def Create(self):
@@ -220,7 +220,7 @@ class MainFrame(wx.Frame):
 
     def QuickRename(self, *_event):
         self.anonList = self.prefDlg.pages['Anonymization'].anonList
-        dlg = QuickRenameDlg(
+        dlg = QuickRenameDialog(
             self, -1, 'Anonymize', size=(250, 160), anonList=self.anonList
         )
         dlg.ShowModal()

--- a/dicomsort/gui/dialogs.py
+++ b/dicomsort/gui/dialogs.py
@@ -5,6 +5,7 @@ import webbrowser
 import wx
 
 from enum import Enum
+from typing import Dict
 from urllib.parse import quote
 
 from dicomsort.gui import icons
@@ -29,11 +30,11 @@ class AboutDlg:
         self.info.SetCopyright(meta.copyright)
         self.info.SetWebSite(meta.website)
 
-        self.GenerateDescription()
+        self.update_description()
 
         AboutBox(self.info, parent=parent)
 
-    def GenerateDescription(self):
+    def update_description(self):
         description = ("      Program designed to sort DICOM images       \n" +
                        "     into directories based upon DICOM header     \n" +
                        "      information. The program also provides      \n" +
@@ -44,7 +45,7 @@ class AboutDlg:
 
 
 class CrashReporter(wx.Dialog):
-    title = 'DICOM Sort Error'
+    title: str = 'DICOM Sort Error'
 
     def __init__(self, parent, **kwargs):
         super(CrashReporter, self).__init__(
@@ -58,21 +59,23 @@ class CrashReporter(wx.Dialog):
         self.create()
         self.SetIcon(icons.main.GetIcon())
 
-    def traceback(self):
-        lines = traceback.format_exception(type, self.value, self._traceback)
-        return '\n'.join(lines)
+    def traceback(self) -> str:
+        return '\n'.join(
+            traceback.format_exception(self.type, self.value, self._traceback)
+        )
 
     def body(self) -> str:
         return \
-            '#### Describe the Issue:\n' + \
-            'A clear and concise description of what the bug is.\n\n' + \
-            '#### Expected Behavior:\n' + \
-            'What you expected to happen.\n\n' + \
-            '#### Steps to Reproduce:\n' + \
-            'How to reproduce the issue.\n\n' + \
-            '## Environment\n' + \
-            f'#### DICOM Sort Version:\n{meta.version}\n\n' + \
-            f'#### Operating System:\n{platform.system()} {platform.release()}\n\n' + \
+            '#### Describe the Issue:\n' \
+            'A clear and concise description of what the bug is.\n\n' \
+            '#### Expected Behavior:\n' \
+            'What you expected to happen.\n\n' \
+            '#### Steps to Reproduce:\n' \
+            'How to reproduce the issue.\n\n' \
+            '## Environment\n' \
+            f'#### DICOM Sort Version:\n{meta.version}\n\n' \
+            f'#### Operating System:\n{platform.system()} '\
+            f'{platform.release()}\n\n' \
             '#### Traceback:\n' + \
             '```\n' + \
             self.traceback() + \
@@ -91,62 +94,66 @@ class CrashReporter(wx.Dialog):
         static.Wrap(380)
         vbox.Add(static, 0, wx.ALL, 10)
 
-        value = '\n'.join(
-            traceback.format_exception(type, self.value, self._traceback)
+        comments = wx.TextCtrl(
+            self, style=wx.TE_MULTILINE, value=self.traceback()
         )
-        self.comments = wx.TextCtrl(self, style=wx.TE_MULTILINE, value=value)
-        vbox.Add(self.comments, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        vbox.Add(comments, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
 
         hbox = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.submit = wx.Button(self, -1, 'File Issue')
-        self.submit.Bind(wx.EVT_BUTTON, self.on_file)
+        submit_button = wx.Button(self, -1, 'File Issue')
+        submit_button.Bind(wx.EVT_BUTTON, self.on_file_issue)
 
-        self.done = wx.Button(self, -1, 'Done')
-        self.done.Bind(wx.EVT_BUTTON, self.on_button)
+        cancel_button = wx.Button(self, -1, 'Cancel')
+        cancel_button.Bind(wx.EVT_BUTTON, self.on_cancel)
 
-        hbox.Add(self.submit, 0, wx.RIGHT, 10)
-        hbox.Add(self.done, 0, wx.RIGHT, 10)
+        hbox.Add(submit_button, 0, wx.RIGHT, 10)
+        hbox.Add(cancel_button, 0, wx.RIGHT, 10)
 
         vbox.Add(hbox, 0, wx.TOP | wx.BOTTOM | wx.ALIGN_RIGHT, 10)
 
         self.SetSizer(vbox)
 
-    def on_file(self, *_event):
+    def on_file_issue(self, *_event):
         webbrowser.open(meta.issue_url + '?body=' + quote(self.body()))
 
-    def on_button(self, event):
+    def close(self, event):
         if self.IsModal():
             self.EndModal(event.EventObject.Id)
         else:
             self.Close()
 
+    def on_cancel(self, event):
+        self.close(event)
+
 
 class HelpDlg(wx.Dialog):
-
-    def __init__(self, parent=None, **kwargs):
+    def __init__(self, parent=None):
 
         super(HelpDlg, self).__init__(
-            parent, -1, '{} Help'.format(meta.pretty_name),
+            parent, -1, f'{meta.pretty_name} Help',
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.TAB_TRAVERSAL
         )
 
-        self.hwin = HtmlWindow(self, -1, size=(400, 200))
+        html_ctrl = HtmlWindow(self, -1, size=(400, 200))
 
-        self.hwin.SetPage(helpHTML)
-        irep = self.hwin.GetInternalRepresentation()
+        html_ctrl.SetPage(helpHTML)
+        irep = html_ctrl.GetInternalRepresentation()
 
-        self.hwin.SetSize((irep.GetWidth(), int(irep.GetHeight() / 4)))
+        html_ctrl.SetSize((irep.GetWidth(), int(irep.GetHeight() / 4)))
         self.Show()
 
-        self.SetClientSize(self.hwin.GetSize())
+        self.SetClientSize(html_ctrl.GetSize())
         self.CenterOnParent(wx.BOTH)
         self.SetFocus()
 
         self.Bind(wx.EVT_CLOSE, self.close)
 
-    def close(self, *_):
-        self.Destroy()
+    def close(self, event):
+        if self.IsModal():
+            self.EndModal(event.EventObject.Id)
+        else:
+            self.Close()
 
 
 class SeriesRemoveOptions(Enum):
@@ -155,20 +162,22 @@ class SeriesRemoveOptions(Enum):
     CANCEL = 3
 
 
-class SeriesRemoveWarningDlg(wx.Dialog):
+class SeriesRemoveWarningDialog(wx.Dialog):
     choice: SeriesRemoveOptions = SeriesRemoveOptions.CANCEL
 
     def __init__(self, parent=None, size=(300, 200), config=None):
-        super(SeriesRemoveWarningDlg, self).__init__(parent, title='BLAH', size=size, style=wx.DEFAULT_DIALOG_STYLE)
+        super(SeriesRemoveWarningDialog, self).__init__(
+            parent, title='BLAH', size=size, style=wx.DEFAULT_DIALOG_STYLE
+        )
 
         vbox = wx.BoxSizer(wx.VERTICAL)
 
-        inputText = ''.join(['Are you sure you want to remove the default\n',
-                             'attribute SeriesDescription?\n\n',
-                             'This may cause filename conflicts unless you\n',
-                             'use the original filenames.'])
+        message = 'Are you sure you want to remove the default\n' \
+                  'attribute SeriesDescription?\n\n' \
+                  'This may cause filename conflicts unless you\n' \
+                  'use the original filenames.'
 
-        txt = wx.StaticText(self, -1, inputText, style=wx.ALIGN_CENTER)
+        txt = wx.StaticText(self, -1, message, style=wx.ALIGN_CENTER)
 
         original_button = wx.Button(
             self, -1, 'Yes. Use original Filenames', size=(-1, 20)
@@ -179,7 +188,11 @@ class SeriesRemoveWarningDlg(wx.Dialog):
         )
         cancel_button = wx.Button(self, -1, 'Cancel', size=(-1, 20))
 
-        original_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.ORIGINAL))
+        original_button.Bind(
+            wx.EVT_BUTTON,
+            lambda e: self.on_button(e, SeriesRemoveOptions.ORIGINAL)
+        )
+
         custom_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CUSTOM))
         cancel_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CANCEL))
 
@@ -190,78 +203,84 @@ class SeriesRemoveWarningDlg(wx.Dialog):
 
         self.SetSizer(vbox)
 
+    def close(self, event):
+        if self.IsModal():
+            self.EndModal(event.EventObject.Id)
+        else:
+            self.Close()
+
     def on_button(self, event, choice: SeriesRemoveOptions):
         self.choice = choice
+        self.close(event)
 
+
+class QuickRenameDialog(wx.Dialog):
+
+    def __init__(self, *args, **kwargs):
+        anon_list = kwargs.pop('anonList')
+
+        super(QuickRenameDialog, self).__init__(*args, **kwargs)
+
+        self.anon_list = anon_list
+
+        vbox = wx.BoxSizer(wx.VERTICAL)
+
+        self.values = self.anon_list.GetReplacementDict()
+        initial_value = self.values.get('PatientName', '')
+
+        txt = wx.StaticText(self, -1, 'PatientName')
+        vbox.Add(txt, 0, wx.TOP | wx.ALIGN_CENTER, 15)
+
+        self.patient_name_text = wx.TextCtrl(
+            self, -1, initial_value, size=(200, 20), style=wx.TE_PROCESS_ENTER
+        )
+
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_accept, self.patient_name_text)
+
+        vbox.Add(self.patient_name_text, 0, wx.TOP | wx.ALIGN_CENTER, 5)
+
+        self.use_as_patient_id = wx.CheckBox(self, -1, 'Use as Patient ID')
+        self.use_as_patient_id.SetValue(True)
+
+        vbox.Add(self.use_as_patient_id, 0, wx.TOP | wx.ALIGN_CENTER, 10)
+
+        ok_button = wx.Button(self, -1, 'Ok')
+        ok_button.Bind(wx.EVT_BUTTON, self.on_accept)
+
+        vbox.Add(ok_button, 0, wx.TOP | wx.ALIGN_CENTER, 15)
+
+        self.SetSizer(vbox)
+
+        self.patient_name_text.SetFocus()
+
+    def get_values(self) -> Dict[str, str]:
+        result = {'PatientName': self.patient_name_text.GetValue()}
+
+        if self.use_as_patient_id.IsChecked():
+            result['PatientID'] = '%(PatientName)s'
+
+        return result
+
+    def on_accept(self, *event):
+        replacements = self.anon_list.GetReplacementDict()
+        replacements.update(self.get_values())
+        self.anon_list.SetReplacementDict(replacements)
+        self.close(event)
+
+    def close(self, event):
         if self.IsModal():
             self.EndModal(event.EventObject.Id)
         else:
             self.Close()
 
 
-class QuickRenameDlg(wx.Dialog):
-
-    def __init__(self, *args, **kwargs):
-        tmp = kwargs.pop('anonList')
-        wx.Dialog.__init__(self, *args, **kwargs)
-        self.anonList = tmp
-        self.values = dict()
-
-        vbox = wx.BoxSizer(wx.VERTICAL)
-
-        self.values = self.anonList.GetReplacementDict()
-        if 'PatientName' in self.values:
-            initial = self.values['PatientName']
-        else:
-            initial = ''
-
-        txt = wx.StaticText(self, -1, 'PatientName')
-        vbox.Add(txt, 0, wx.TOP | wx.ALIGN_CENTER, 15)
-
-        self.patientName = wx.TextCtrl(self, -1, initial, size=(200, 20),
-                                       style=wx.TE_PROCESS_ENTER)
-
-        self.Bind(wx.EVT_TEXT_ENTER, self.OnAccept, self.patientName)
-
-        vbox.Add(self.patientName, 0, wx.TOP | wx.ALIGN_CENTER, 5)
-
-        self.samecheck = wx.CheckBox(self, -1, 'Use as Patient ID')
-        self.samecheck.SetValue(True)
-
-        vbox.Add(self.samecheck, 0, wx.TOP | wx.ALIGN_CENTER, 10)
-
-        self.btnOK = wx.Button(self, -1, 'Ok')
-        self.btnOK.Bind(wx.EVT_BUTTON, self.OnAccept)
-
-        vbox.Add(self.btnOK, 0, wx.TOP | wx.ALIGN_CENTER, 15)
-
-        self.SetSizer(vbox)
-
-        self.patientName.SetFocus()
-
-    def GetValues(self):
-        res = dict()
-        res['PatientName'] = self.patientName.GetValue()
-
-        if self.samecheck.IsChecked():
-            res['PatientID'] = '%(PatientName)s'
-
-        return res
-
-    def OnAccept(self, *evnt):
-        oldDict = self.anonList.GetReplacementDict()
-        oldDict.update(self.GetValues())
-        self.anonList.SetReplacementDict(oldDict)
-        self.Close()
-
-
-class UpdateDlg(wx.Dialog):
+class UpdateDialog(wx.Dialog):
     def __init__(self, parent, version):
-        super(UpdateDlg, self).__init__(parent, size=(300, 170), style=wx.OK)
-        message = ''.join([
-            'A new version of {} is available.\n'.format(meta.pretty_name),
-            'You are running Version %s and the newest is %s.\n'
-        ])
+        super(UpdateDialog, self).__init__(parent, size=(300, 170), style=wx.OK)
+
+        message = f'A new version of {meta.pretty_name} is available.\n'\
+                  f'You are running Version {dicomsort.__version__} and '\
+                  f'the newest is {version}.'
 
         vbox = wx.BoxSizer(wx.VERTICAL)
 
@@ -272,31 +291,32 @@ class UpdateDlg(wx.Dialog):
 
         vbox.Add(head, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, 15)
 
-        txt = wx.StaticText(
-            self, -1, label=message % (dicomsort.__version__, version),
-            style=wx.ALIGN_CENTER)
-        vbox.Add(txt, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
+        message_ctrl = wx.StaticText(self, -1, label=message, style=wx.ALIGN_CENTER)
+        vbox.Add(message_ctrl, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
 
-        self.link = hyperlink.HyperLinkCtrl(self, -1)
-        self.link.SetURL(URL=meta.website)
-        self.link.SetLabel(label='Click here to obtain the update')
-        self.link.SetToolTip(meta.website)
-        self.link.AutoBrowse(False)
+        self.hyperlink = hyperlink.HyperLinkCtrl(self, -1)
+        self.hyperlink.SetURL(URL=meta.website)
+        self.hyperlink.SetLabel(label='Click here to obtain the update')
+        self.hyperlink.SetToolTip(meta.website)
+        self.hyperlink.AutoBrowse(False)
 
-        self.Bind(hyperlink.EVT_HYPERLINK_LEFT, self.OnUpdate, self.link)
+        self.Bind(hyperlink.EVT_HYPERLINK_LEFT, self.on_update, self.hyperlink)
 
-        vbox.Add(self.link, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 0)
+        vbox.Add(self.hyperlink, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 0)
 
-        ok = wx.Button(self, -1, "OK")
-        vbox.Add(ok, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 15)
-        self.Bind(wx.EVT_BUTTON, self.OnClose, ok)
+        ok_button = wx.Button(self, -1, 'OK')
+        vbox.Add(ok_button, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 15)
+        self.Bind(wx.EVT_BUTTON, self.close, ok_button)
 
         self.SetSizer(vbox)
         self.CenterOnParent()
 
-    def OnUpdate(self, *evnt):
-        self.link.GotoURL(self.link.GetURL())
-        self.Destroy()
+    def close(self, event):
+        if self.IsModal():
+            self.EndModal(event.EventObject.Id)
+        else:
+            self.Close()
 
-    def OnClose(self, *evnt):
-        self.Destroy()
+    def on_update(self, *event):
+        self.hyperlink.GotoURL(self.hyperlink.GetURL())
+        self.close(event)

--- a/dicomsort/gui/dialogs.py
+++ b/dicomsort/gui/dialogs.py
@@ -193,8 +193,15 @@ class SeriesRemoveWarningDialog(wx.Dialog):
             lambda e: self.on_button(e, SeriesRemoveOptions.ORIGINAL)
         )
 
-        custom_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CUSTOM))
-        cancel_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CANCEL))
+        custom_button.Bind(
+            wx.EVT_BUTTON,
+            lambda e: self.on_button(e, SeriesRemoveOptions.CUSTOM)
+        )
+
+        cancel_button.Bind(
+            wx.EVT_BUTTON,
+            lambda e: self.on_button(e, SeriesRemoveOptions.CANCEL)
+        )
 
         vbox.Add(txt, 1, wx.ALL | wx.ALIGN_CENTER, 10)
         vbox.Add(original_button, 0, wx.ALL | wx.ALIGN_CENTER, 5)
@@ -276,7 +283,8 @@ class QuickRenameDialog(wx.Dialog):
 
 class UpdateDialog(wx.Dialog):
     def __init__(self, parent, version):
-        super(UpdateDialog, self).__init__(parent, size=(300, 170), style=wx.OK)
+        super(UpdateDialog, self)\
+            .__init__(parent, size=(300, 170), style=wx.OK)
 
         message = f'A new version of {meta.pretty_name} is available.\n'\
                   f'You are running Version {dicomsort.__version__} and '\
@@ -291,7 +299,9 @@ class UpdateDialog(wx.Dialog):
 
         vbox.Add(head, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.TOP, 15)
 
-        message_ctrl = wx.StaticText(self, -1, label=message, style=wx.ALIGN_CENTER)
+        message_ctrl = wx.StaticText(
+            self, -1, label=message, style=wx.ALIGN_CENTER
+        )
         vbox.Add(message_ctrl, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
 
         self.hyperlink = hyperlink.HyperLinkCtrl(self, -1)

--- a/dicomsort/gui/dialogs.py
+++ b/dicomsort/gui/dialogs.py
@@ -1,5 +1,5 @@
 import dicomsort
-import os
+import platform
 import traceback
 import webbrowser
 import wx
@@ -62,7 +62,7 @@ class CrashReporter(wx.Dialog):
         lines = traceback.format_exception(type, self.value, self._traceback)
         return '\n'.join(lines)
 
-    def body(self):
+    def body(self) -> str:
         return \
             '#### Describe the Issue:\n' + \
             'A clear and concise description of what the bug is.\n\n' + \
@@ -71,8 +71,8 @@ class CrashReporter(wx.Dialog):
             '#### Steps to Reproduce:\n' + \
             'How to reproduce the issue.\n\n' + \
             '## Environment\n' + \
-            '#### DICOM Sort Version:\n{}\n\n'.format(meta.version) + \
-            '#### Operating System:\n{}\n\n'.format(' '.join(os.uname())) + \
+            f'#### DICOM Sort Version:\n{meta.version}\n\n' + \
+            f'#### Operating System:\n{platform.system()} {platform.release()}\n\n' + \
             '#### Traceback:\n' + \
             '```\n' + \
             self.traceback() + \

--- a/dicomsort/gui/dialogs.py
+++ b/dicomsort/gui/dialogs.py
@@ -4,6 +4,7 @@ import traceback
 import webbrowser
 import wx
 
+from enum import Enum
 from urllib.parse import quote
 
 from dicomsort.gui import icons
@@ -148,12 +149,17 @@ class HelpDlg(wx.Dialog):
         self.Destroy()
 
 
-class SeriesRemoveWarningDlg(wx.Dialog):
+class SeriesRemoveOptions(Enum):
+    ORIGINAL = 1
+    CUSTOM = 2
+    CANCEL = 3
 
-    def __init__(self, parent, id=-1, size=(300, 200), config=None):
-        wx.Dialog.__init__(
-            self, parent, id, 'Remove Series Description?', size=size
-        )
+
+class SeriesRemoveWarningDlg(wx.Dialog):
+    choice: SeriesRemoveOptions = SeriesRemoveOptions.CANCEL
+
+    def __init__(self, parent=None, size=(300, 200), config=None):
+        super(SeriesRemoveWarningDlg, self).__init__(parent, title='BLAH', size=size, style=wx.DEFAULT_DIALOG_STYLE)
 
         vbox = wx.BoxSizer(wx.VERTICAL)
 
@@ -164,41 +170,33 @@ class SeriesRemoveWarningDlg(wx.Dialog):
 
         txt = wx.StaticText(self, -1, inputText, style=wx.ALIGN_CENTER)
 
-        change = wx.Button(
+        original_button = wx.Button(
             self, -1, 'Yes. Use original Filenames', size=(-1, 20)
         )
 
-        accept = wx.Button(
+        custom_button = wx.Button(
             self, -1, 'Yes. Use Custom Filenames', size=(-1, 20)
         )
-        cancel = wx.Button(self, -1, 'Cancel', size=(-1, 20))
+        cancel_button = wx.Button(self, -1, 'Cancel', size=(-1, 20))
 
-        change.Bind(wx.EVT_BUTTON, self.OnChange)
-        accept.Bind(wx.EVT_BUTTON, self.OnAccept)
-        cancel.Bind(wx.EVT_BUTTON, self.OnCancel)
-
-        self.Bind(wx.EVT_CLOSE, self.OnCancel)
+        original_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.ORIGINAL))
+        custom_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CUSTOM))
+        cancel_button.Bind(wx.EVT_BUTTON, lambda e: self.on_button(e, SeriesRemoveOptions.CANCEL))
 
         vbox.Add(txt, 1, wx.ALL | wx.ALIGN_CENTER, 10)
-        vbox.Add(change, 0, wx.ALL | wx.ALIGN_CENTER, 5)
-        vbox.Add(accept, 0, wx.ALL | wx.ALIGN_CENTER, 5)
-        vbox.Add(cancel, 0, wx.ALL | wx.ALIGN_CENTER, 5)
+        vbox.Add(original_button, 0, wx.ALL | wx.ALIGN_CENTER, 5)
+        vbox.Add(custom_button, 0, wx.ALL | wx.ALIGN_CENTER, 5)
+        vbox.Add(cancel_button, 0, wx.ALL | wx.ALIGN_CENTER, 5)
 
         self.SetSizer(vbox)
 
-        self.Destroy()
+    def on_button(self, event, choice: SeriesRemoveOptions):
+        self.choice = choice
 
-    def OnChange(self, *evnt):
-        self.choice = 1
-        self.Destroy()
-
-    def OnCancel(self, *evnt):
-        self.choice = 0
-        self.Destroy()
-
-    def OnAccept(self, *evnt):
-        self.choice = 2
-        self.Destroy()
+        if self.IsModal():
+            self.EndModal(event.EventObject.Id)
+        else:
+            self.Close()
 
 
 class QuickRenameDlg(wx.Dialog):

--- a/dicomsort/gui/widgets.py
+++ b/dicomsort/gui/widgets.py
@@ -8,7 +8,10 @@ import wx.html
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin, TextEditMixin
 
 from dicomsort.gui import errors, events
-from dicomsort.gui.dialogs import SeriesRemoveOptions, SeriesRemoveWarningDialog
+from dicomsort.gui.dialogs import (
+    SeriesRemoveOptions,
+    SeriesRemoveWarningDialog
+)
 
 
 class FileDropTarget(wx.FileDropTarget):

--- a/dicomsort/gui/widgets.py
+++ b/dicomsort/gui/widgets.py
@@ -8,7 +8,7 @@ import wx.html
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin, TextEditMixin
 
 from dicomsort.gui import errors, events
-from dicomsort.gui.dialogs import SeriesRemoveWarningDlg
+from dicomsort.gui.dialogs import SeriesRemoveOptions, SeriesRemoveWarningDlg
 
 
 class FileDropTarget(wx.FileDropTarget):
@@ -452,21 +452,23 @@ class FieldSelector(wx.Panel):
     def DeselectItem(self, *evnt):
         index = self.selected.GetSelection()
 
+        # No-op if there is no new selection
         if index == -1:
             return
 
         if index == self.selected.GetCount() - 1 and self.has_default():
-            warn = SeriesRemoveWarningDlg(None)
-            warn.ShowModal()
+            dialog = SeriesRemoveWarningDlg(None)
+            dialog.ShowModal()
 
-            if warn.choice == 0:
+            if dialog.choice == SeriesRemoveOptions.CANCEL:
                 return
-            elif warn.choice == 1:
-                # change to original filenames
-                cfg = self.GetParent().config
-                cfg['FilenameFormat']['Selection'] = 1
+
+            elif dialog.choice == SeriesRemoveOptions.ORIGINAL:
+                # Select the configuration option to use the original filename
+                config = self.GetParent().config
+                config['FilenameFormat']['Selection'] = 1
                 page = self.GetParent().prefDlg.pages['FilenameFormat']
-                page.UpdateFromConfig(cfg)
+                page.UpdateFromConfig(config)
 
         self.selected.Delete(index)
 

--- a/dicomsort/gui/widgets.py
+++ b/dicomsort/gui/widgets.py
@@ -8,7 +8,7 @@ import wx.html
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin, TextEditMixin
 
 from dicomsort.gui import errors, events
-from dicomsort.gui.dialogs import SeriesRemoveOptions, SeriesRemoveWarningDlg
+from dicomsort.gui.dialogs import SeriesRemoveOptions, SeriesRemoveWarningDialog
 
 
 class FileDropTarget(wx.FileDropTarget):
@@ -433,7 +433,7 @@ class FieldSelector(wx.Panel):
 
         if inc < 0 and (self.selected.Count == 1 or index == 0):
             return
-        elif (inc > 0 and index == self.selected.Count - 1):
+        elif inc > 0 and index == self.selected.Count - 1:
             return
 
         prop = self.selected.GetStringSelection()
@@ -457,7 +457,7 @@ class FieldSelector(wx.Panel):
             return
 
         if index == self.selected.GetCount() - 1 and self.has_default():
-            dialog = SeriesRemoveWarningDlg(None)
+            dialog = SeriesRemoveWarningDialog(None)
             dialog.ShowModal()
 
             if dialog.choice == SeriesRemoveOptions.CANCEL:

--- a/tests/gui/test_dialogs.py
+++ b/tests/gui/test_dialogs.py
@@ -9,6 +9,7 @@ from dicomsort.gui.dialogs import (
     AboutDlg,
     CrashReporter,
     QuickRenameDlg,
+    SeriesRemoveOptions,
     SeriesRemoveWarningDlg,
     UpdateDlg,
     webbrowser,
@@ -93,23 +94,26 @@ class TestAboutDialog(WxTestCase):
 
 
 class TestSeriesRemoveWarningDlg(WxTestCase):
-    def test_on_change(self):
+    def test_on_original(self):
         dlg = SeriesRemoveWarningDlg(self.frame)
-        dlg.OnChange()
+        dlg.on_button(None, SeriesRemoveOptions.ORIGINAL)
+        dlg.Destroy()
 
-        assert dlg.choice == 1
+        assert dlg.choice == SeriesRemoveOptions.ORIGINAL
 
     def test_on_cancel(self):
         dlg = SeriesRemoveWarningDlg(self.frame)
-        dlg.OnCancel()
+        dlg.on_button(None, SeriesRemoveOptions.CANCEL)
+        dlg.Destroy()
 
-        assert dlg.choice == 0
+        assert dlg.choice == SeriesRemoveOptions.CANCEL
 
-    def test_on_accept(self):
+    def test_on_custom(self):
         dlg = SeriesRemoveWarningDlg(self.frame)
-        dlg.OnAccept()
+        dlg.on_button(None, SeriesRemoveOptions.CUSTOM)
+        dlg.Destroy()
 
-        assert dlg.choice == 2
+        assert dlg.choice == SeriesRemoveOptions.CUSTOM
 
 
 class TestQuickRenameDlg(WxTestCase):

--- a/tests/gui/test_dialogs.py
+++ b/tests/gui/test_dialogs.py
@@ -1,17 +1,18 @@
-import dicomsort
-import os
+import platform
 import sys
 
 from urllib.parse import parse_qs, urlparse
+
+import dicomsort
 
 from dicomsort.gui.anonymizer import AnonymizeList
 from dicomsort.gui.dialogs import (
     AboutDlg,
     CrashReporter,
-    QuickRenameDlg,
+    QuickRenameDialog,
     SeriesRemoveOptions,
-    SeriesRemoveWarningDlg,
-    UpdateDlg,
+    SeriesRemoveWarningDialog,
+    UpdateDialog,
     webbrowser,
 )
 from tests.shared import WxTestCase
@@ -40,16 +41,15 @@ class TestCrashReporter(WxTestCase):
         # Has the expected information
         assert dicomsort.__version__ in body
 
-        platform = ' '.join(os.uname())
-        assert platform in body
-
+        assert platform.system() in body
+        assert platform.release() in body
         assert reporter.traceback() in body
 
-    def test_on_file(self, mocker):
+    def test_on_file_issue(self, mocker):
         mock = mocker.patch.object(webbrowser, 'open')
         reporter = CrashReporter(self.frame)
 
-        reporter.on_file()
+        reporter.on_file_issue()
 
         assert mock.call_count == 1
 
@@ -68,17 +68,13 @@ class TestCrashReporter(WxTestCase):
 
 
 class TestUpdateDlg(WxTestCase):
-    def test_on_close(self):
-        dlg = UpdateDlg(self.frame, '1.2.3')
-        dlg.OnClose()
-
     def test_on_update(self, mocker):
-        dlg = UpdateDlg(self.frame, '1.2.3')
+        dlg = UpdateDialog(self.frame, '1.2.3')
         url = dicomsort.Metadata.website
 
-        mock = mocker.patch.object(dlg.link, 'GotoURL')
+        mock = mocker.patch.object(dlg.hyperlink, 'GotoURL')
 
-        dlg.OnUpdate()
+        dlg.on_update()
 
         mock.assert_called_once_with(url)
 
@@ -95,21 +91,21 @@ class TestAboutDialog(WxTestCase):
 
 class TestSeriesRemoveWarningDlg(WxTestCase):
     def test_on_original(self):
-        dlg = SeriesRemoveWarningDlg(self.frame)
+        dlg = SeriesRemoveWarningDialog(self.frame)
         dlg.on_button(None, SeriesRemoveOptions.ORIGINAL)
         dlg.Destroy()
 
         assert dlg.choice == SeriesRemoveOptions.ORIGINAL
 
     def test_on_cancel(self):
-        dlg = SeriesRemoveWarningDlg(self.frame)
+        dlg = SeriesRemoveWarningDialog(self.frame)
         dlg.on_button(None, SeriesRemoveOptions.CANCEL)
         dlg.Destroy()
 
         assert dlg.choice == SeriesRemoveOptions.CANCEL
 
     def test_on_custom(self):
-        dlg = SeriesRemoveWarningDlg(self.frame)
+        dlg = SeriesRemoveWarningDialog(self.frame)
         dlg.on_button(None, SeriesRemoveOptions.CUSTOM)
         dlg.Destroy()
 
@@ -119,14 +115,14 @@ class TestSeriesRemoveWarningDlg(WxTestCase):
 class TestQuickRenameDlg(WxTestCase):
     def test_no_patient_name_anonlist(self):
         a = AnonymizeList(self.frame)
-        dlg = QuickRenameDlg(self.frame, anonList=a)
+        dlg = QuickRenameDialog(self.frame, anonList=a)
 
         expected = {
             'PatientName': '',
             'PatientID': '%(PatientName)s',
         }
 
-        assert dlg.GetValues() == expected
+        assert dlg.get_values() == expected
 
     def test_patient_name_anonlist(self):
         name = 'Patient0'
@@ -134,14 +130,14 @@ class TestQuickRenameDlg(WxTestCase):
         a.SetStringItems(['PatientName'])
         a.SetReplacementDict({'PatientName': name})
 
-        dlg = QuickRenameDlg(self.frame, anonList=a)
+        dlg = QuickRenameDialog(self.frame, anonList=a)
 
         expected = {
             'PatientName': name,
             'PatientID': '%(PatientName)s',
         }
 
-        assert dlg.GetValues() == expected
+        assert dlg.get_values() == expected
 
     def test_on_accept(self):
         name = 'Patient0'
@@ -149,9 +145,11 @@ class TestQuickRenameDlg(WxTestCase):
         a.SetStringItems(['PatientName', 'PatientID'])
         a.SetReplacementDict({'PatientName': name, 'PatientID': 'ignored'})
 
-        dlg = QuickRenameDlg(self.frame, anonList=a)
+        dlg = QuickRenameDialog(self.frame, anonList=a)
 
-        dlg.OnAccept()
+        dlg.on_accept()
 
-        assert a.GetReplacementDict()['PatientID'] == '%(PatientName)s'
-        assert a.GetReplacementDict()['PatientName'] == name
+        replacements = a.GetReplacementDict()
+
+        assert replacements['PatientID'] == '%(PatientName)s'
+        assert replacements['PatientName'] == name

--- a/tests/gui/test_help.py
+++ b/tests/gui/test_help.py
@@ -6,4 +6,4 @@ from tests.shared import WxTestCase
 class TestHelpDialog(WxTestCase):
     def test_constructor(self):
         self.dlg = HelpDlg(self.frame)
-        assert isinstance(self.dlg.hwin, HtmlWindow)
+

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -2,6 +2,9 @@ import wx
 
 
 class WxTestCase:
+    app: wx.App
+    frame: wx.Frame
+
     def setup(self):
         self.app = wx.App()
         self.frame = wx.Frame(None)


### PR DESCRIPTION
* `SeriesRemoveWarningDialog` is updated such that the `choice` attribute exists an uses an enum for better usability
* Updates `CrashReporter` to use `platform` module instead of `os.uname` so as to not fail on Windows.
* Misc. cleanup of `gui.dialogs`